### PR TITLE
Support newer pillow version

### DIFF
--- a/install.py
+++ b/install.py
@@ -162,7 +162,7 @@ def check_dependencies():
           im_ver = Image.__version__
         except AttributeError:
           im_ver = Image.VERSION
-        assert im_ver >= '1.1.5'
+        assert im_ver >= '9.4'
         print('    Python Imaging Library ...... OK')
     except ImportError:
         print('    !!! Python Imaging Library .. Not found')

--- a/src/acbfdocument.py
+++ b/src/acbfdocument.py
@@ -110,7 +110,7 @@ class ACBFDocument():
         image_uri = ImageURI(image_id)
         self.coverpage = self.load_image(image_uri)
         self.cover_thumb = self.coverpage.copy()
-        self.cover_thumb.thumbnail((200, 200), Image.NEAREST)
+        self.cover_thumb.thumbnail((200, 200), Image.Resampling.NEAREST)
 
         # get authors
         for author in self.bookinfo.findall("author"):

--- a/src/comicpage.py
+++ b/src/comicpage.py
@@ -473,8 +473,9 @@ class ComicPage():
 
                   current_chunk = self.remove_xml_tags(chunk)
                   if current_chunk != '':
-                    chunk_size = chunk_size + draw.textsize(current_chunk, font=font)[0]
-                    font_height = font.getsize(current_chunk)[1]
+                    chunk_size = chunk_size + draw.textlength(current_chunk, font=font)
+                    font_box = font.getbbox(current_chunk)
+                    font_height = font_box[3] - font_box[1]
 
                 text_size = (chunk_size, font_height + 1)
                 
@@ -597,8 +598,9 @@ class ComicPage():
 
                     current_chunk = self.remove_xml_tags(chunk)
                     if current_chunk != '':
-                      chunk_size = chunk_size + draw.textsize(current_chunk, font=font)[0]
-                      font_height = font.getsize(current_chunk)[1]
+                      chunk_size = chunk_size + draw.textlength(current_chunk, font=font)
+                      font_box = font.getbbox(current_chunk)
+                      font_height = font_box[3] - font_box[1]
 
                   text_size = (chunk_size, font_height + 1)
                   upper_right_corner_fits = point_inside_polygon(current_pointer[0] + text_size[0], current_pointer[1], polygon)
@@ -656,7 +658,7 @@ class ComicPage():
 
           # rotate image back to original rotation after text is drawn
           if text_area[3] != 0:
-            draw_image = draw_image.rotate(text_area[3], Image.BILINEAR, 1)
+            draw_image = draw_image.rotate(text_area[3], Image.Resampling.BILINEAR, 1)
             rotated_image_size = draw_image.size
             left = (rotated_image_size[0] - original_polygon_size[0])//2
             upper = (rotated_image_size[1] - original_polygon_size[1])//2
@@ -930,7 +932,7 @@ class ComicPage():
 
                   current_chunk = self.remove_xml_tags(chunk)
                   if current_chunk != '':
-                    chunk_size = chunk_size + draw.textsize(current_chunk, font=font)[0]
+                    chunk_size = chunk_size + draw.textlength(current_chunk, font=font)
                 drawing_word = drawing_word + 1
                 line_length = line_length + chunk_size
               change_in_height = int(round((((line[2][1] - line[0][1]) - (current_character_height + 1)) / 2), 0))
@@ -1180,7 +1182,7 @@ class ComicPage():
               if old_line != line:
                 justify_space = 0
                 if is_commentary or (text_area[5].upper() == 'FORMAL' and idx + 1 == len(lines)): #left align
-                  space_between_words = draw.textsize(' ', font=font)[0]
+                  space_between_words = draw.textlength(' ', font=font)
                 elif text_area[5].upper() == 'FORMAL': #justify
                   w_count = len(line[1].strip().split(' ')) - 1
                   if is_last_line:
@@ -1189,9 +1191,9 @@ class ComicPage():
                     justify_space = (max_coordinate - line[2][0]) / w_count
                   else:
                     justify_space = 0
-                  space_between_words = draw.textsize(' ', font=font)[0] + justify_space
+                  space_between_words = draw.textlength(' ', font=font) + justify_space
                 else: #center
-                  space_between_words = draw.textsize('n n', font=font)[0] - draw.textsize('nn', font=font)[0]
+                  space_between_words = draw.textlength('n n', font=font) - draw.textlength('nn', font=font)
                   line_length = line[2][0] - line[0][0]
                   mid_bubble_x = ((get_frame_span(text_area[4])[0] + get_frame_span(text_area[4])[2]) / 2) - line_length / 2
                   max_coordinate_x = current_pointer[0] + int((max_coordinate - line[2][0])/2)
@@ -1221,19 +1223,19 @@ class ComicPage():
                   current_pointer = (current_pointer[0], current_pointer[1] - int(current_character_height * 0.7))
                 elif use_superscript:
                   draw.text(current_pointer, current_word, font=font_small, fill=font_color)
-                  #draw.rectangle((current_pointer[0] - 1, current_pointer[1] - 1, current_pointer[0] + draw.textsize(current_word, font=font_small)[0] + 1, current_pointer[1] + int(character_height * 0.7) + 1), outline=font_color)
+                  #draw.rectangle((current_pointer[0] - 1, current_pointer[1] - 1, current_pointer[0] + draw.textlength(current_word, font=font_small) + 1, current_pointer[1] + int(character_height * 0.7) + 1), outline=font_color)
                   if '<A_HREF' in chunk_upper:
                     reference_id = re.sub("[^#]*#", '', chunk)
                     reference_id = re.sub("\".*", '', reference_id)
                     for idxr, reference in enumerate(self.references):
                       if reference_id == reference[0]:
                         rectangle = [(current_pointer[0] - 5, current_pointer[1] - 5),
-                                     (current_pointer[0] + draw.textsize(current_word, font=font_small)[0] + 5, current_pointer[1] - 5),
-                                     (current_pointer[0] + draw.textsize(current_word, font=font_small)[0] + 5, current_pointer[1] + int(current_character_height * 0.7) + 5),
+                                     (current_pointer[0] + draw.textlength(current_word, font=font_small) + 5, current_pointer[1] - 5),
+                                     (current_pointer[0] + draw.textlength(current_word, font=font_small) + 5, current_pointer[1] + int(current_character_height * 0.7) + 5),
                                      (current_pointer[0] - 5, current_pointer[1] + int(current_character_height * 0.7) + 5)]
                         self.references[idxr] = (reference[0], reference[1], rectangle)
             
-                text_size = (draw.textsize(current_word, font=font_small)[0], int(current_character_height * 0.5))
+                text_size = (draw.textlength(current_word, font=font_small), int(current_character_height * 0.5))
                 strikethrough_rectangle = [current_pointer[0] - int(space_between_words/2),
                                            current_pointer[1] + int(current_character_height/2) + 1,
                                            current_pointer[0] + text_size[0] + int(space_between_words/2),
@@ -1245,10 +1247,10 @@ class ComicPage():
                 word_start = current_pointer
                 text_size = [0, current_character_height]
                 word_count = len(current_word.strip().split(' '))
-                line_length_total = draw.textsize(current_word.strip(), font=font)[0]
+                line_length_total = draw.textlength(current_word.strip(), font=font)
                 word_length_total = 0
                 for one_word in current_word.split(' '):
-                  word_length_total = word_length_total + draw.textsize(one_word.strip(), font=font)[0]
+                  word_length_total = word_length_total + draw.textlength(one_word.strip(), font=font)
 
                 space_length = line_length_total - word_length_total
                 if word_count > 1:
@@ -1256,7 +1258,7 @@ class ComicPage():
                 elif space_length > 0:
                   one_space = space_length
                 else:
-                  one_space = draw.textsize(current_word + ' M', font=font)[0] - draw.textsize(current_word + 'M', font=font)[0]
+                  one_space = draw.textlength(current_word + ' M', font=font) - draw.textlength(current_word + 'M', font=font)
 
                 #print '#' + current_word.encode('ascii', 'ignore') + '#', line_length_total, word_length_total, space_length, one_space
                 
@@ -1268,7 +1270,7 @@ class ComicPage():
                   elif font == e_font or font == s_font:
                     current_pointer = (current_pointer[0] - 1, current_pointer[1])
                   draw.text(current_pointer, one_word + ' ', font=font, fill=font_color)
-                  word_length = max(draw.textsize(one_word.strip(), font=font)[0] + one_space, draw.textsize(one_word.strip() + ' ', font=font)[0])
+                  word_length = max(draw.textlength(one_word.strip(), font=font) + one_space, draw.textlength(one_word.strip() + ' ', font=font))
                   if text_area[5].upper() == 'FORMAL':
                     word_length = word_length + justify_space
                   text_size = (text_size[0] + word_length, current_character_height)
@@ -1279,7 +1281,7 @@ class ComicPage():
                     current_pointer = (current_pointer[0] + 1, current_pointer[1])
                   
                 #draw.text(current_pointer, current_word, font=font, fill=font_color)
-                #text_size = (draw.textsize(current_word, font=font)[0], current_character_height)
+                #text_size = (draw.textlength(current_word, font=font), current_character_height)
                 #current_pointer = (current_pointer[0] + text_size[0], current_pointer[1])
                 strikethrough_rectangle = [word_start[0] - int(space_between_words/2),
                                            word_start[1] + int(current_character_height/2) + 1,
@@ -1291,7 +1293,7 @@ class ComicPage():
 
           # rotate image back to original rotation after text is drawn
           if text_area[3] != 0:
-            draw_image = draw_image.rotate(text_area[3], Image.BILINEAR, 1)
+            draw_image = draw_image.rotate(text_area[3], Image.Resampling.BILINEAR, 1)
             rotated_image_size = draw_image.size
             left = (rotated_image_size[0] - original_polygon_size[0])//2
             upper = (rotated_image_size[1] - original_polygon_size[1])//2
@@ -1399,22 +1401,22 @@ def get_PixBufImage(ComicPageObject, size, zoom_level):
           size = (size[0], int((float(cpPILBackgroundImage.size[1])*float(wpercent))))
           
         if ComicPageObject._window.preferences.get_value("image_resize_filter") == "0":
-          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.NEAREST)
+          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.Resampling.NEAREST)
         elif ComicPageObject._window.preferences.get_value("image_resize_filter") == "1":
-          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.BILINEAR)
+          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.Resampling.BILINEAR)
         elif ComicPageObject._window.preferences.get_value("image_resize_filter") == "2":
-          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.BICUBIC)
+          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.Resampling.BICUBIC)
         else:
-          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.ANTIALIAS)
+          cpPILBackgroundImage = cpPILBackgroundImage.resize(size, Image.Resampling.LANCZOS)
       elif zoom_level != 3:
         if ComicPageObject._window.preferences.get_value("image_resize_filter") == "0":
-          cpPILBackgroundImage.thumbnail(size, Image.NEAREST)
+          cpPILBackgroundImage.thumbnail(size, Image.Resampling.NEAREST)
         elif ComicPageObject._window.preferences.get_value("image_resize_filter") == "1":
-          cpPILBackgroundImage.thumbnail(size, Image.BILINEAR)
+          cpPILBackgroundImage.thumbnail(size, Image.Resampling.BILINEAR)
         elif ComicPageObject._window.preferences.get_value("image_resize_filter") == "2":
-          cpPILBackgroundImage.thumbnail(size, Image.BICUBIC)
+          cpPILBackgroundImage.thumbnail(size, Image.Resampling.BICUBIC)
         else:
-          cpPILBackgroundImage.thumbnail(size, Image.ANTIALIAS)
+          cpPILBackgroundImage.thumbnail(size, Image.Resampling.LANCZOS)
 
       # adjust image sharpness
       if int(ComicPageObject._window.image_sharpness_value * 10) != 0 and ComicPageObject._window.sharpness_button_toggle == True:

--- a/src/library.py
+++ b/src/library.py
@@ -1607,7 +1607,7 @@ class LibraryDialog(gtk.Dialog):
 
         # coverpage
         coverpage = acbf_document.coverpage
-        coverpage.thumbnail((int(coverpage.size[0]*150/float(coverpage.size[1])),150), Image.NEAREST)
+        coverpage.thumbnail((int(coverpage.size[0]*150/float(coverpage.size[1])),150), Image.Resampling.NEAREST)
         output_directory = os.path.join(os.path.join(constants.CONFIG_DIR, 'Covers'), acbf_document.book_title[list(acbf_document.book_title.items())[0][0]][0].upper())
         if not os.path.exists(output_directory):
           os.makedirs(output_directory, 0o700)


### PR DESCRIPTION
This adds support for newer pillow version. It broke on version 8 and pip install 9.5, so I changed the install to `>9.4` but earlier 9 version should still work.

There is some tweaking that needs to be done to the font sizing.